### PR TITLE
Refactor breakpoints

### DIFF
--- a/_sass/config/_variables.scss
+++ b/_sass/config/_variables.scss
@@ -20,12 +20,15 @@ $link-color: $blue;
 $link-hover-color: $blue-light;
 
 // viewport breakpoints
-$screen-xs-max: 480px;
-$screen-sm-min: 767px;
-$screen-sm-max: 768px;
-$screen-md-max: 1024px;
-$screen-lg-max: 1366px;
-$screen-xl-max: 1920px;
+$large-desktop-min: 1920px;
+$desktop-max: $large-desktop-min - 1px;
+$desktop-min: 1366px;
+$small-desktop-max: $desktop-min - 1px;
+$small-desktop-min: 1024px;
+$tablet-max: $small-desktop-min - 1px;
+$tablet-min: 768px;
+$large-mobile-max: $tablet-min - 1px;
+$large-mobile-min: 480px;
 
 //spacing
 $u-space-tiny: 0.5rem;

--- a/_sass/modules/_footer.scss
+++ b/_sass/modules/_footer.scss
@@ -6,7 +6,7 @@
   background-repeat: no-repeat;
   color: white;
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $tablet-min) {
     background-image: url("/assets/img/svg/HabitatMap-Monogram-Footer-White.svg"),
       linear-gradient(to right, $gray-medium, $gray-medium 50%, $green 50%);
   }
@@ -18,11 +18,11 @@
   @include flex-direction(column);
   background: $gray-medium;
 
-  @media screen and (max-width: ($screen-sm-min)) {
+  @media screen and (max-width: $large-mobile-max) {
     padding: $u-space-default 4vw;
   }
 
-  @media screen and (min-width: ($screen-md-max)) {
+  @media screen and (min-width: $small-desktop-min) {
     @include flex-direction(row);
   }
 }
@@ -36,7 +36,7 @@
   margin-bottom: $u-space-default;
   vertical-align: top;
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $tablet-min) {
     display: inline-block;
   }
 }
@@ -46,7 +46,7 @@
   display: inline-block;
   margin: 0;
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $small-desktop-min) {
     @include flex(0 0 35%);
   }
 }
@@ -76,11 +76,11 @@
   @include flex-direction(column);
   @include justify-content(space-between);
 
-  @media screen and (max-width: ($screen-sm-min)) {
+  @media screen and (max-width: $large-mobile-max) {
     padding: $u-space-default 4vw 12rem;
   }
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $small-desktop-min) {
     padding-bottom: 0;
   }
 }

--- a/_sass/modules/_header.scss
+++ b/_sass/modules/_header.scss
@@ -4,7 +4,7 @@ header {
   grid-column: full;
   display: grid;
   padding: 2rem;
-  @media screen and (min-width: $screen-sm-min) {
+  @media screen and (min-width: $small-desktop-min) {
     grid-template-columns: 1fr auto;
     grid-column-gap: 1rem;
   }
@@ -14,7 +14,7 @@ header {
 header > h1 {
   display: inline-block;
   padding-bottom: 1rem;
-  @media screen and (min-width: $screen-sm-min) {
+  @media screen and (min-width: $small-desktop-min) {
     padding-bottom: 0;
   }
   a,
@@ -22,7 +22,7 @@ header > h1 {
     text-decoration: none;
     border: 0;
     color: $gray;
-    @media screen and (min-width: $screen-sm-min) {
+    @media screen and (min-width: $small-desktop-min) {
       padding: 1rem;
     }
   }
@@ -33,7 +33,7 @@ header > h1 {
 
 // main menu, is a grid item
 header > nav {
-  @media screen and (min-width: $screen-sm-min) {
+  @media screen and (min-width: $small-desktop-min) {
     float: right;
   }
   ul {
@@ -42,7 +42,7 @@ header > nav {
     li {
       margin-right: 2rem;
       display: inline-block;
-      @media screen and (min-width: $screen-sm-min) {
+      @media screen and (min-width: $small-desktop-min) {
         margin-right: 0;
       }
       a,
@@ -50,7 +50,7 @@ header > nav {
         color: $gray;
         text-decoration: none;
         border: 0;
-        @media screen and (min-width: $screen-sm-min) {
+        @media screen and (min-width: $small-desktop-min) {
           padding: 1rem;
         }
         &[data-current="current page"] {

--- a/_sass/modules/_panel.scss
+++ b/_sass/modules/_panel.scss
@@ -3,20 +3,20 @@
   @include flex-direction(column);
   padding: $u-space-default 4vw;
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $tablet-min) {
     @include flex-direction(row);
     padding-left: 10vw;
     padding-right: 10vw;
   }
 
-  @media screen and (min-width: $screen-lg-max) {
+  @media screen and (min-width: $desktop-min) {
     padding-left: 15vw;
     padding-right: 15vw;
   }
 }
 
 .panel--footer {
-  @media screen and (max-width: $screen-sm-min) {
+  @media screen and (max-width: $large-mobile-max) {
     padding: 0;
   }
 }
@@ -29,7 +29,7 @@
   background-repeat: no-repeat;
   background-size: 100% auto;
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $tablet-min) {
     background-position: center right;
     background-size: 50% auto;
     padding-bottom: 6rem;

--- a/_sass/modules/_typography.scss
+++ b/_sass/modules/_typography.scss
@@ -14,7 +14,7 @@ body {
 .heading--large {
   font-size: $base-font-size3;
 
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $tablet-min) {
     font-size: $base-font-size4;
   }
 }

--- a/_sass/partials/_grid.scss
+++ b/_sass/partials/_grid.scss
@@ -1,5 +1,5 @@
 .split--half {
-  @media screen and (min-width: $screen-sm-max) {
+  @media screen and (min-width: $tablet-min) {
     @include flex(0 0 50%);
 
     &:first-of-type {


### PR DESCRIPTION
This changes naming of the breakpoints in a way that seems to be clearer to me. In general, I think that a variable representing the minimum screen size should be set to maximum of the previous, smaller screen size + 1px. At the same time, this way in media queries you'll usually have `(min-width: $screen-size-min)` or `(max-width: $screen-size-max)`, which makes sense to me. This PR adjusts the breakpoints variables accordingly. 