### PR TITLE
Aircasting: links to the mobile map in the subdomain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,13 +6,13 @@ force = false
 
 [[redirects]]
 from = "/markers"
-to = "http://aircasting.org/mobile_map"
+to = "http://aircasting.habitatmap.org/mobile_map"
 status = 301
 force = false
 
 [[redirects]]
 from = "/markers/*"
-to = "http://aircasting.org/mobile_map"
+to = "http://aircasting.habitatmap.org/mobile_map"
 status = 301
 force = false
 

--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -122,6 +122,6 @@ section: about
     <p class="p--body">
       AirCasting is an open-source environmental data visualization platform that consists of an Android app and online mapping system and is one of the largest open-source databases of community-collected air quality measurements ever created.
     </p>
-    <a href="#" class="button button--ac">AirCasting Maps</a>
+    <a href="http://aircasting.habitatmap.org/mobile_map" class="button button--ac">AirCasting Maps</a>
   </div>
 </section>

--- a/pages/aircasting.md
+++ b/pages/aircasting.md
@@ -23,7 +23,7 @@ section: aircasting
       <img class="logo logo--body" alt="AirCasting" src="assets/img/svg/AirCasting-Logo-Body.svg" />
     </div>
     <div class="split--order-secondary">
-      <a href="http://aircasting.org/mobile_map" class="button button--ac ac-intro__button">AirCasting Maps</a>
+      <a href="http://aircasting.habitatmap.org/mobile_map" class="button button--ac ac-intro__button">AirCasting Maps</a>
       <a href="https://play.google.com/store/apps/details?id=pl.llp.aircasting&hl=en" class="button button--ac ac-intro__button">Download App</a>
     </div>
   </div>

--- a/pages/index.md
+++ b/pages/index.md
@@ -82,7 +82,7 @@ section: home
     </p>
   </div>
   <div class="split--40 u--align-right">
-    <a href="#" class="button button--ac ac-intro__button">AirCasting Maps</a>
+    <a href="http://aircasting.habitatmap.org/mobile_map" class="button button--ac ac-intro__button">AirCasting Maps</a>
     <a href="#" class="button button--ac ac-intro__button">Download App</a>
   </div>
 </section>


### PR DESCRIPTION
The DNS for aircasting.habitatmap.org is setup, thus the links are good to go for production.