### PR TITLE
Panel image fixes

### DIFF
--- a/_sass/modules/_images.scss
+++ b/_sass/modules/_images.scss
@@ -3,7 +3,9 @@
 }
 
 .img--margin-top {
-  margin-top: $u-space-default;
+  @media screen and (min-width: $tablet-min) {
+    margin-top: $u-space-default;
+  }
 }
 
 .img--alternate-medium {

--- a/_sass/modules/_panel.scss
+++ b/_sass/modules/_panel.scss
@@ -1,12 +1,12 @@
 .panel {
   @include flexbox;
   @include flex-direction(column);
-  @include flex-wrap(wrap);
   @include justify-content(space-between);
   padding: $u-space-default 4vw;
 
   @media screen and (min-width: $tablet-min) {
     @include flex-direction(row);
+    @include flex-wrap(wrap);
     padding-left: 10vw;
     padding-right: 10vw;
   }


### PR DESCRIPTION
Fixes '"Why AirBeam" text is missing on mobile portrait' by removing `flex-wrap: wrap` for mobile. Also removes excessive space above images on the How it Works page on mobile.