### PR TITLE
Replace hero image and tweak section for tablets

### DIFF
--- a/_sass/modules/_panel.scss
+++ b/_sass/modules/_panel.scss
@@ -64,9 +64,17 @@
   }
 
   @media screen and (min-width: $tablet-min) {
+    background-position: center top;
+    background-size: cover;
+  }
+
+  @media screen and (min-width: $tablet-min) {
+    padding-bottom: 5.5rem;
+  }
+
+  @media screen and (min-width: $small-desktop-min) {
     background-position: center right;
     background-size: 50% auto;
-    padding-bottom: 5.5rem;
   }
 
   @media screen and (min-width: $large-desktop-min) {
@@ -134,6 +142,10 @@
 
 .panel__heading {
   max-width: 27rem;
+
+  @media screen and (min-width: $tablet-min) and (max-width: $tablet-max) {
+    font-size: 2.25rem;
+  }
 }
 
 .panel--quote,

--- a/assets/img/habitatmap-home-airbeam-aircasting.jpg
+++ b/assets/img/habitatmap-home-airbeam-aircasting.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4dadd78a388f70a2643bd37c747ef60b5330f2140c573c2c832ff777b2ded619
-size 22479
+oid sha256:86adb2cd850e714dd144e7645100aceea418bbb51d5638dee6c83a59d62ac399
+size 159391


### PR DESCRIPTION
The changed section on tablet looks like this:

![Screen Shot 2019-12-30 at 19 07 12](https://user-images.githubusercontent.com/457999/71594575-bd298800-2b38-11ea-82d9-50d2cba172dc.png)
