### PR TITLE
Remove excessive bolding of various links in posts and post lists

### DIFF
--- a/_sass/config/_typography.scss
+++ b/_sass/config/_typography.scss
@@ -120,14 +120,8 @@ a,
     }
   }
 
-  .post-list__title & {
-    font-weight: bold;
-  }
-
   .p--body &,
   .post-nav & {
-    font-weight: bold;
-
     [data-current="about"] & {
       color: $teal;
     }


### PR DESCRIPTION
The bold font (Moderat Bold) is enough, the extra bolding is ugly.

Before:

![Screenshot 2019-12-31 at 17 01 03](https://user-images.githubusercontent.com/457999/71626810-5b782500-2bef-11ea-9771-b9cf9ac56b2e.png)
![Screenshot 2019-12-31 at 17 00 53](https://user-images.githubusercontent.com/457999/71626809-5b782500-2bef-11ea-99b5-c57c77edb13a.png)
![Screenshot 2019-12-31 at 16 44 57](https://user-images.githubusercontent.com/457999/71626808-5adf8e80-2bef-11ea-830d-42d7482293e4.png)

After:

![Screenshot 2019-12-31 at 17 01 42](https://user-images.githubusercontent.com/457999/71626821-69c64100-2bef-11ea-9db3-69150b01659b.png)
![Screenshot 2019-12-31 at 17 01 20](https://user-images.githubusercontent.com/457999/71626820-69c64100-2bef-11ea-8254-a9a0ad8be1ba.png)
![Screenshot 2019-12-31 at 17 01 52](https://user-images.githubusercontent.com/457999/71626822-69c64100-2bef-11ea-836a-7b76c9584d25.png)


