### PR TITLE
Aircasting page fixes

### DIFF
--- a/pages/about/index.md
+++ b/pages/about/index.md
@@ -67,7 +67,7 @@ image: /assets/img/pages/about-habitatmap/airbeam.jpg
       <p class="p--body">
         Since launching HabitatMap in 2006, he has worked with dozens of community-based organizations and schools to create planning and advocacy maps that publicize the issues they care about most.
       </p>
-      <a href="/about/history" class="button button--ac">Learn more</a>
+      <a href="/about/history" class="button button--ac">Learn More</a>
     </div>
   </div>
 </section>
@@ -89,7 +89,7 @@ image: /assets/img/pages/about-habitatmap/airbeam.jpg
     <p class="p--body">
       The AirBeam measures particulate matter with proven accuracy and when used in conjunction with the AirCasting platform - or a custom solution - helps community-based organizations, educators, academics, regulators, city managers, and citizen scientists map air pollution and organize for clean air.
     </p>
-    <a href="/airbeam" class="button button--hm">Learn more</a>
+    <a href="/airbeam" class="button button--hm">Learn More</a>
   </div>
 
   <div class="split--50 split--padding-left">

--- a/pages/airbeam/index.md
+++ b/pages/airbeam/index.md
@@ -44,7 +44,7 @@ image: /assets/img/about-airbeam-01.jpg
         <p class="p--body">
           The AirBeam was designed by HabitatMap to raise awareness of the disproportionate environmental burdens borne by low-income communities and communities of color and equip these communities with tools to advocate for equity and improved quality of life.
         </p>
-        <a href="/airbeam/how-it-works" class="button button--ac">Learn more</a>
+        <a href="/airbeam/how-it-works" class="button button--ac">Learn More</a>
       </div>
       <div class="split--50 split--padding-left u--align-right">
         <img
@@ -89,7 +89,7 @@ image: /assets/img/about-airbeam-01.jpg
     </h2>
   </div>
 
-  {% include testimonials-slider.html testimonials = site.testimonials %}
+{% include testimonials-slider.html testimonials = site.testimonials %}
 
   <a href="/airbeam/faq" class="badge-link badge-link--light-hm">
     <span class="u--vertically-centered">Questions? Check out our FAQ</span>

--- a/pages/aircasting.md
+++ b/pages/aircasting.md
@@ -61,7 +61,7 @@ image: /assets/img/aircasting-map-screenshot.png
       <p class="p--body">
         The AirBeam measures harmful microscopic air particles (particulate matter), humidity, and temperature.  In mobile mode, the AirBeam can be worn to capture personal exposures.  In fixed mode, it can be installed indoors or outdoors - it’s weather resistant and doesn’t need a shelter - to keep tabs on pollution levels in your home, office, backyard, or neighborhood 24/7.
       </p>
-      <a href="/airbeam/how-it-works" class="button">Learn more</a>
+      <a href="/airbeam/how-it-works" class="button">Learn More</a>
     </div>
     <img
       alt="AirCasting App on Mobile"

--- a/pages/aircasting.md
+++ b/pages/aircasting.md
@@ -63,12 +63,13 @@ image: /assets/img/aircasting-map-screenshot.png
       </p>
       <a href="/airbeam/how-it-works" class="button">Learn More</a>
     </div>
-    <img
-      alt="AirCasting App on Mobile"
-      class="img img--alternate-medium lazyload"
-      data-src="/assets/img/pages/aircasting/app-screenshot.jpg?nf_resize=fit&w=750"
-      src="/assets/img/pages/aircasting/app-screenshot.jpg?nf_resize=fit&w=20"
-    />
+    <div class="split--50 split--padding-left">
+      <img
+        alt="AirCasting App on Mobile"
+        class="img img--alternate-medium lazyload"
+        data-src="/assets/img/pages/aircasting/app-screenshot.jpg?nf_resize=fit&w=750"
+        src="/assets/img/pages/aircasting/app-screenshot.jpg?nf_resize=fit&w=20"
+      />
     </div>
   </div>
 </section>


### PR DESCRIPTION
- there was an opening split div missing from the view around the last image
- 'Learn more' button text changed to 'Learn More'

Before:

![Screenshot 2020-01-21 at 14 23 42](https://user-images.githubusercontent.com/457999/72808382-baaedf80-3c59-11ea-849d-7542481ab9f8.png)

After:
![Screenshot 2020-01-21 at 14 24 09](https://user-images.githubusercontent.com/457999/72808383-bb477600-3c59-11ea-8d2c-e8669019ca57.png)
